### PR TITLE
Add support for rules

### DIFF
--- a/analyzer.js
+++ b/analyzer.js
@@ -72,7 +72,7 @@ const getScenarioCode = (source, feature, file) => {
   };
 
   const handleRule = (rule) => {
-    console.log(inRule ? '  - ' : ' - ', rule.name);
+    console.log(' - ', rule.name);
     endLocations.shift();
     inRule = true;
     rule.children.forEach(handleChild);

--- a/example/features/rules.feature
+++ b/example/features/rules.feature
@@ -1,0 +1,74 @@
+Feature: A feature with multiple rules
+  Description of the feature
+
+  Rule: Rule 1
+    Description of first rule
+
+    Scenario: Scenario 1.1
+      Description of first scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 1.2
+      Description of second scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 1.3
+      Description of third scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+  Rule: Rule 2
+    Description of second rule
+
+    Scenario: Scenario 2.1
+      Description of first scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 2.2
+      Description of second scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 2.3
+      Description of third scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+  Rule: Rule 3
+    Description of thrid rule
+
+    Scenario: Scenario 3.1
+      Description of first scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 3.2
+      Description of second scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 3.3
+      Description of third scenario
+
+      Given I have something
+      When I do something
+      Then something happens

--- a/tests/analyzer_test.js
+++ b/tests/analyzer_test.js
@@ -72,4 +72,17 @@ describe('Analyzer', () => {
     expect(scenariosTitles).to.include('Scenario 3.3');
     expect(scenarios.length).equal(9);
   });
+  it('Should extract the code of scenarios in rules', async () => {
+    const features = await analyse('**/rules.feature', path.join(__dirname, '..', 'example'));
+    const scenarios = features.reduce((acc, feature) => {
+      acc.push(...feature.scenario);
+      return acc;
+    }, []);
+
+    for (let scenario of scenarios) {
+      expect(scenario.code).to.include("Scenario");
+      expect(scenario.code).to.not.include("Rule");
+      expect(scenario.code.split('\n').length).to.equal(7);
+    }
+  });
 });

--- a/tests/analyzer_test.js
+++ b/tests/analyzer_test.js
@@ -51,4 +51,25 @@ describe('Analyzer', () => {
     const features = await analyse('**/empty.feature', path.join(__dirname, '..', 'example'));
     expect(features[0].error).not.equal(undefined);
   });
+
+  it('Should include scenarios from rules', async () => {
+    const features = await analyse('**/rules.feature', path.join(__dirname, '..', 'example'));
+    const scenarios = features.reduce((acc, feature) => {
+      acc.push(...feature.scenario);
+      return acc;
+    }, []);
+    const scenariosTitles = scenarios.map(scenarioData => scenarioData.name);
+
+    expect(features.length).equal(1);
+    expect(scenariosTitles).to.include('Scenario 1.1');
+    expect(scenariosTitles).to.include('Scenario 1.2');
+    expect(scenariosTitles).to.include('Scenario 1.3');
+    expect(scenariosTitles).to.include('Scenario 2.1');
+    expect(scenariosTitles).to.include('Scenario 2.2');
+    expect(scenariosTitles).to.include('Scenario 2.3');
+    expect(scenariosTitles).to.include('Scenario 3.1');
+    expect(scenariosTitles).to.include('Scenario 3.2');
+    expect(scenariosTitles).to.include('Scenario 3.3');
+    expect(scenarios.length).equal(9);
+  });
 });


### PR DESCRIPTION
As of [Gherkin 6](https://github.com/cucumber/common/blob/main/gherkin/CHANGELOG.md#6013---2018-09-25) multiple`Scenario`s can be grouped using [`Rule`s](https://cucumber.io/docs/gherkin/reference/#rule). The `check-cucumber` tool currently does not support the `Rule` keyword and thus cannot find scenarios in rules. This PR adds support for the import of scenarios from rules into Testomatio.

The main change is in `getScenarioCode`: when the child of a feature is a rule, the children of the rule are processed recursively.
Additionally the calculation of a scenario's end position had to be updated. Previously the end position was defined as the start position of the next child or the end of the source in case of the last child. Now there is the additional case that the last child of a rule is followed by another rule. To generalize all cases, the start positions of all rules and scenarios are calculated in a preprocessing step using `getLocations`. The end positions are then calculated from the start positions.

I also added an example and corresponding test cases. The tests ensure that all scenarios in rules are found and that the correct code fragment is extracted.