### PR TITLE
Add option to include contextual information in code fragments

### DIFF
--- a/analyzer.js
+++ b/analyzer.js
@@ -7,8 +7,7 @@ const path = require('path');
 let workDir;
 const invalidKeys = ['And', 'But'];
 
-const getLocation = ({ feature, scenario, rule, background }) => {
-  const message = feature || scenario || rule || background;
+const getLocation = (message) => {
   if (message.tags && message.tags.length) {
     return message.tags[0].location.line - 1;
   }
@@ -16,10 +15,10 @@ const getLocation = ({ feature, scenario, rule, background }) => {
 };
 
 const getLocations = ({ feature, scenario, rule, background }) => {
-  if (feature) return feature.children.flatMap(getLocations);
-  if (scenario) return [ getLocation({ scenario }) ];
-  if (rule) return [getLocation({ rule }), ...rule.children.flatMap(getLocations)];
-  if (background) return [ getLocation({ background }) ];
+  if (feature) return [getLocation(feature), ...feature.children.flatMap(getLocations) ];
+  if (scenario) return [ getLocation(scenario) ];
+  if (rule) return [getLocation(rule), ...rule.children.flatMap(getLocations)];
+  if (background) return [ getLocation(background) ];
   return [];
 };
 
@@ -47,8 +46,7 @@ const getScenarioCode = (source, feature, file, {
   const fileName = path.relative(workDir, file);
   const scenarios = [];
 
-  const featureStart = getLocation({ feature });
-  const startLocations = getLocations({ feature });
+  const [featureStart, ...startLocations] = getLocations({ feature });
   const [featureEnd, ...endLocations] = [...startLocations, sourceArray.length];
   const context = includeFeatureCode ? sourceArray.slice(featureStart, featureEnd) : [];
 
@@ -144,7 +142,7 @@ const parseFile = (file, scenarioCodeOptions) => new Promise((resolve, reject) =
             console.log(chalk.red('Title for feature is empty, skipping'));
             featureData.error = `${fileName} : Empty feature`;
           }
-          featureData.line = getLocation({feature: data[1].gherkinDocument.feature}) + 1;
+          featureData.line = getLocation(data[1].gherkinDocument.feature) + 1;
           featureData.tags = data[1].gherkinDocument.feature.tags.map(t => t.name.slice(1));
           featureData.scenario = getScenarioCode(data[0].source.data, data[1].gherkinDocument.feature, file, scenarioCodeOptions);
         } else {

--- a/bin/check.js
+++ b/bin/check.js
@@ -32,10 +32,17 @@ program
   .option('--create', 'Create tests and suites for missing IDs')
   .option('--no-empty', 'Remove empty suites after import')
   .option('--keep-structure', 'Prefer structure of source code over structure in Testomat.io')
-  .option('--no-detached', 'Don\t mark all unmatched tests as detached')
+  .option('--no-detached', 'Don\'t mark all unmatched tests as detached')
+  .option('--include-features', 'Add description of feature to scenario code')
+  .option('--include-rules', 'Add description of parent rule sections to scenario code')
+  .option('--include-backgrounds', 'Add description and steps of relevant background sections to scenario code')
   .action(async (filesArg, opts) => {
     const isPattern = checkPattern(filesArg);
-    const features = await analyze(filesArg || '**/*.feature', opts.dir || process.cwd());
+    const features = await analyze(filesArg || '**/*.feature', opts.dir || process.cwd(), {
+      includeFeatureCode: opts.includeFeatures,
+      includeRuleCode: opts.includeRules,
+      includeBackgroundCode: opts.includeBackgrounds,
+    });
     if (opts.cleanIds || opts.unsafeCleanIds) {
       let idMap = {};
       if (apiKey) {

--- a/example/features/rules.feature
+++ b/example/features/rules.feature
@@ -1,8 +1,14 @@
 Feature: A feature with multiple rules
   Description of the feature
 
+  Background: 
+    Given all rules have something
+
   Rule: Rule 1
     Description of first rule
+
+    Background: 
+      Given the first rule has something
 
     Scenario: Scenario 1.1
       Description of first scenario
@@ -28,6 +34,9 @@ Feature: A feature with multiple rules
   Rule: Rule 2
     Description of second rule
 
+    Background: 
+      Given the second rule has something
+
     Scenario: Scenario 2.1
       Description of first scenario
 
@@ -50,7 +59,10 @@ Feature: A feature with multiple rules
       Then something happens
 
   Rule: Rule 3
-    Description of thrid rule
+    Description of third rule
+
+    Background: 
+      Given the third rule has something
 
     Scenario: Scenario 3.1
       Description of first scenario

--- a/example/features/rules.feature
+++ b/example/features/rules.feature
@@ -1,0 +1,74 @@
+Feature: A feature with multiple rules
+  Description of the feature
+
+  Rule: Rule 1
+    Description of first rule
+
+    Scenario: Scenario 1.1
+      Description of first scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 1.2
+      Description of second scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 1.3
+      Description of third scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+  Rule: Rule 2
+    Description of second rule
+
+    Scenario: Scenario 2.1
+      Description of first scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 2.2
+      Description of second scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 2.3
+      Description of third scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+  Rule: Rule 3
+    Description of thrid rule
+
+    Scenario: Scenario 3.1
+      Description of first scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 3.2
+      Description of second scenario
+
+      Given I have something
+      When I do something
+      Then something happens
+
+    Scenario: Scenario 3.3
+      Description of third scenario
+
+      Given I have something
+      When I do something
+      Then something happens

--- a/tests/analyzer_test.js
+++ b/tests/analyzer_test.js
@@ -51,4 +51,25 @@ describe('Analyzer', () => {
     const features = await analyse('**/empty.feature', path.join(__dirname, '..', 'example'));
     expect(features[0].error).not.equal(undefined);
   });
+
+  it('Should include scenarios from rules', async () => {
+    const features = await analyse('**/rules.feature', path.join(__dirname, '..', 'example'));
+    const scenarios = features.reduce((acc, feature) => {
+      acc.push(...feature.scenario);
+      return acc;
+    }, []);
+    const scenariosTitles = scenarios.map(scenarioData => scenarioData.name);
+
+    expect(features.length).equal(1);
+    expect(scenariosTitles).to.include('Scenario 1.1');
+    expect(scenariosTitles).to.include('Scenario 1.2');
+    expect(scenariosTitles).to.include('Scenario 1.3');
+    expect(scenariosTitles).to.include('Scenario 2.1');
+    expect(scenariosTitles).to.include('Scenario 2.2');
+    expect(scenariosTitles).to.include('Scenario 2.3');
+    expect(scenariosTitles).to.include('Scenario 3.1');
+    expect(scenariosTitles).to.include('Scenario 3.2');
+    expect(scenariosTitles).to.include('Scenario 3.3');
+    expect(scenarios.length).equal(9);
+  });
 });

--- a/tests/analyzer_test.js
+++ b/tests/analyzer_test.js
@@ -72,4 +72,114 @@ describe('Analyzer', () => {
     expect(scenariosTitles).to.include('Scenario 3.3');
     expect(scenarios.length).equal(9);
   });
+
+  it('Does not include the feature, rule and background description by default', async () => {
+    const features = await analyse('**/rules.feature', path.join(__dirname, '..', 'example'), {
+      includeFeatureCode: false,
+      includeRuleCode: false,
+      includeBackgroundCode: false,
+    });
+    const scenarios = features.reduce((acc, feature) => {
+      acc.push(...feature.scenario);
+      return acc;
+    }, []);
+
+    expect(features.length).equal(1);
+    for (let scenario of scenarios) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.not.include('Description of the feature');
+      expect(code).to.not.include('Description of first rule');
+      expect(code).to.not.include('Given all rules have something');
+    }
+    expect(scenarios.length).equal(9);
+  });
+
+  it('Can include the features description', async () => {
+    const features = await analyse('**/rules.feature', path.join(__dirname, '..', 'example'), {
+      includeFeatureCode: true,
+      includeRuleCode: false,
+      includeBackgroundCode: false,
+    });
+    const scenarios = features.reduce((acc, feature) => {
+      acc.push(...feature.scenario);
+      return acc;
+    }, []);
+
+    expect(features.length).equal(1);
+    for (let scenario of scenarios) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.include('Description of the feature');
+    }
+    expect(scenarios.length).equal(9);
+  });
+
+  it('Can include the parent rule description', async () => {
+    const features = await analyse('**/rules.feature', path.join(__dirname, '..', 'example'), {
+      includeFeatureCode: false,
+      includeRuleCode: true,
+      includeBackgroundCode: false,
+    });
+    const scenarios = features.reduce((acc, feature) => {
+      acc.push(...feature.scenario);
+      return acc;
+    }, []);
+
+    expect(features.length).equal(1);
+    for (let scenario of scenarios.slice(0, 3)) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.include('Description of first rule');
+      expect(code).to.not.include('Description of second rule');
+      expect(code).to.not.include('Description of third rule');
+    }
+    for (let scenario of scenarios.slice(3, 6)) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.not.include('Description of first rule');
+      expect(code).to.include('Description of second rule');
+      expect(code).to.not.include('Description of third rule');
+    }
+    for (let scenario of scenarios.slice(6, 9)) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.not.include('Description of first rule');
+      expect(code).to.not.include('Description of second rule');
+      expect(code).to.include('Description of third rule');
+    }
+    expect(scenarios.length).equal(9);
+  });
+
+  it('Can include background steps', async () => {
+    const features = await analyse('**/rules.feature', path.join(__dirname, '..', 'example'), {
+      includeFeatureCode: false,
+      includeRuleCode: false,
+      includeBackgroundCode: true,
+    });
+    const scenarios = features.reduce((acc, feature) => {
+      acc.push(...feature.scenario);
+      return acc;
+    }, []);
+
+    expect(features.length).equal(1);
+    for (let scenario of scenarios) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.include('Given all rules have something');
+    }
+    for (let scenario of scenarios.slice(0, 3)) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.include('Given the first rule has something');
+      expect(code).to.not.include('Given the second rule has something');
+      expect(code).to.not.include('Given the third rule has something');
+    }
+    for (let scenario of scenarios.slice(3, 6)) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.not.include('Given the first rule has something');
+      expect(code).to.include('Given the second rule has something');
+      expect(code).to.not.include('Given the third rule has something');
+    }
+    for (let scenario of scenarios.slice(6, 9)) {
+      const code = scenario.code.split('\n').map(line => line.trim());
+      expect(code).to.not.include('Given the first rule has something');
+      expect(code).to.not.include('Given the second rule has something');
+      expect(code).to.include('Given the third rule has something');
+    }
+    expect(scenarios.length).equal(9);
+  });
 });


### PR DESCRIPTION
When a scenario is imported to Testomatio, the corresponding source code from the `*.feature` file is also uploaded. However, seeing just the scenarios code might not be sufficient or even misleading. Most importantly, there is currently no way to see the steps of a `Background` section on Testomatio.

This PR adds CLI flags to include the source code of relevant `Background` sections as well as the names, descriptions and tags of parent features and rules.

```shell
$> npx check-cucumber --help
  ...
  --include-features           Add description of feature to scenario code
  --include-rules              Add description of parent rule sections to scenario code
  --include-backgrounds        Add description and steps of relevant background sections to scenario code
```

For example, when all three CLI flags are set, the tool will now extract the following code fragment for "Scenario 2.2" from [`example/features/rules.feature`](https://github.com/just95/check-cucumber/blob/code-context/example/features/rules.feature):

```gherkin
Feature: A feature with multiple rules
  Description of the feature

  Background:
    Given all rules have something

  Rule: Rule 2
    Description of second rule

    Background:
      Given the second rule has something

    Scenario: Scenario 2.2
      Description of second scenario

      Given I have something
      When I do something
      Then something happens
```

This PR depends on the support for rules added in #38. The `getLocations` function added in #38 is also reused to extract the correct source code fragments for features, rules and backgrounds. The main change is the implementation of a new handler for the `Background` keyword in `getSourceCode` and the addition of a `context` variable to keep track of the source code of rules and backgrounds.
