### PR TITLE
Add flag to test for IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ TESTOMATIO=API_KEY npx check-cucumber -d example/cucumber --clean-ids
 
 TESTOMATIO is API key for old project.
 
+### Check IDs
+
+To check where all scenarios and features have Testomatio IDs run this command with `--check-ids` option.
+
+```
+TESTOMATIO=API_KEY npx check-cucumber -d example/cucumber --check-ids
+```
+
+If there is a feature or scenario without a Testomatio ID, the command exits with a non-zero status code.
+If all features and scenarios have Testomatio IDs, the command imports them into Testomatio.
+
 ### Import Into a Branch
 
 Tests can be imported into a specific branch if `TESTOMATIO_BRANCH` parameter is used.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ TESTOMATIO is API key for old project.
 
 ### Check IDs
 
-To check where all scenarios and features have Testomatio IDs run this command with `--check-ids` option.
+To check whether all scenarios and features have Testomatio IDs run this command with `--check-ids` option.
 
 ```
 TESTOMATIO=API_KEY npx check-cucumber -d example/cucumber --check-ids

--- a/bin/check.js
+++ b/bin/check.js
@@ -29,7 +29,7 @@ program
   .option('-U, --update-ids', 'Update test and suite with testomatio ids')
   .option('--clean-ids', 'Remove testomatio ids from test and suite')
   .option('--purge, --unsafe-clean-ids', 'Remove testomatio ids from test and suite without server verification')
-  .option('--check-ids', 'Do not synchronize with testomatio, only check if all suites and tests have IDs')
+  .option('--check-ids', 'Ensure that all suites and tests have testomatio ids before the import')
   .option('--create', 'Create tests and suites for missing IDs')
   .option('--no-empty', 'Remove empty suites after import')
   .option('--keep-structure', 'Prefer structure of source code over structure in Testomat.io')
@@ -91,42 +91,43 @@ program
       }
 
       if (opts.checkIds) {
-        console.log('Checking test IDs...');
-        const {checkedFiles, suitesWithoutIds, testsWithoutIds} = checkFiles(features, opts.dir || process.cwd());
+        console.log("Checking test IDs...");
+        const { checkedFiles, suitesWithoutIds, testsWithoutIds } = checkFiles(
+          features,
+          opts.dir || process.cwd()
+        );
         console.log(`${checkedFiles.length} Files checked`);
         if (suitesWithoutIds.length || testsWithoutIds.length) {
           console.log(
             `\n ⚠️  ${suitesWithoutIds.length} suites and ${testsWithoutIds.length} tests are missing test IDs!`
           );
-          console.log(
-            "    Use the `--update-ids` flag to update the files.\n"
-          );
+          console.log("    Use the `--update-ids` flag to update the files.\n");
           process.exit(1);
         }
-      } else {
-        const resp = reporter.send({
-          branch,
-          sync: opts.sync || opts.updateIds,
-          noempty: !opts.empty,
-          'no-detach': !isPattern || !opts.detached,
-          structure: opts.keepStructure,
-          create: opts.create || false,
-        });
+      }
 
-        if (opts.sync || opts.updateIds) {
-          console.log('    Wait for Testomatio to synchronize tests...');
-          await resp;
-        }
-        if (opts.updateIds) {
-          console.log('Updating test IDs...');
-          if (apiKey) {
-            reporter.getIds().then(idMap => {
-              const updatedFiles = updateFiles(features, idMap, opts.dir || process.cwd());
-              console.log(`${updatedFiles.length} Files updated`);
-            });
-          } else {
-            console.log(' ✖️  API key not provided');
-          }
+      const resp = reporter.send({
+        branch,
+        sync: opts.sync || opts.updateIds,
+        noempty: !opts.empty,
+        'no-detach': !isPattern || !opts.detached,
+        structure: opts.keepStructure,
+        create: opts.create || false,
+      });
+
+      if (opts.sync || opts.updateIds) {
+        console.log('    Wait for Testomatio to synchronize tests...');
+        await resp;
+      }
+      if (opts.updateIds) {
+        console.log('Updating test IDs...');
+        if (apiKey) {
+          reporter.getIds().then(idMap => {
+            const updatedFiles = updateFiles(features, idMap, opts.dir || process.cwd());
+            console.log(`${updatedFiles.length} Files updated`);
+          });
+        } else {
+          console.log(' ✖️  API key not provided');
         }
       }
     } else {

--- a/bin/check.js
+++ b/bin/check.js
@@ -101,6 +101,7 @@ program
           console.log(
             "    Use the `--update-ids` flag to update the files.\n"
           );
+          process.exit(1);
         }
       } else {
         const resp = reporter.send({

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -157,4 +157,26 @@ describe('Utils', () => {
     expect(file1).not.to.include('@T4d7f20ed');
     //expect(file2).not.to.include('@T22222');
   });
+
+  it('should check for suite and test ids', async () => {
+    const workDir = path.join(__dirname, '..', 'example/features');
+    const features = await analyse('**/valid_sample.feature', workDir);
+    const { checkedFiles, suitesWithoutIds, testsWithoutIds } = util.checkFiles(
+      features,
+      workDir
+    );
+
+    expect(features.length).equal(1);
+    expect(checkedFiles).deep.equal([
+      path.join(workDir, 'valid_sample.feature')
+    ]);
+    expect(suitesWithoutIds).deep.equal([
+      'Business rules'
+    ]);
+    expect(testsWithoutIds).deep.equal([
+      'do something',
+      'do something twice',
+      'Search testomat in google'
+    ]);
+  });
 });

--- a/util.js
+++ b/util.js
@@ -1,3 +1,4 @@
+const chalk = require("chalk");
 const insertLine = require('insert-line');
 const fs = require('fs');
 
@@ -123,7 +124,40 @@ function cleanFiles(features, testomatioMap = {}, workDir, dangerous = false) {
   }
   return files;
 }
+
+function checkFiles(features, workDir) {
+  const checkedFiles = [];
+  const suitesWithoutIds = [];
+  const testsWithoutIds = [];
+  for (const suite of features) {
+    if (!suite.scenario) continue;
+    if (!suite.scenario.length) continue;
+
+    const featureFile = `${workDir}/${suite.scenario[0].file}`;
+    checkedFiles.push(featureFile);
+
+    const suiteTags = suite.tags.map(tag => `@${tag}`);
+    const suiteIdTag = suiteTags.find(parseSuite);
+
+    if (!suiteIdTag) {
+      suitesWithoutIds.push(suite.feature);
+    }
+
+    for (const scenario of suite.scenario) {
+      const scenarioTags = scenario.tags.map(tag => `@${tag}`);
+      const scenarioIdTag = scenarioTags.find(parseTest);
+
+      if (!scenarioIdTag) {
+        testsWithoutIds.push(scenario.name);
+      }
+    }
+  }
+
+  return { checkedFiles, suitesWithoutIds, testsWithoutIds };
+}
+
 module.exports = {
   updateFiles,
   cleanFiles,
+  checkFiles,
 };

--- a/util.js
+++ b/util.js
@@ -1,4 +1,3 @@
-const chalk = require("chalk");
 const insertLine = require('insert-line');
 const fs = require('fs');
 


### PR DESCRIPTION
As part of our continuous integration pipeline we are using `check-cucumber` to synchronize Gherkin specifications with Testomatio. However, we still require the developers to run `check-cucumber --update-ids` locally. To make sure they don't forget this step, we want the pipeline to fail if there are features or scenarios without an ID.

Therefore we've implemented a `--check-ids` flag in our fork that checks whether IDs have been assigned to all features and scenarios before they are imported into Testomatio and exits with status code `1` if an ID is missing.

The check is performed after the input files have been analyzed. To tell whether a suite or scenario has an ID tag, the existing `parseSuite` and `parseTest` helper functions are reused.